### PR TITLE
Disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 5
+    # Disable version updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Prevent dependabot from opening pull requests for version updates. This change does not impact security updates.

# Related issues

N/A

# Proposed changes

- Set `open-pull-requests-limit` to 0, following the configuration advice in [the GitHub documentation](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file).